### PR TITLE
Fix NullReferenceException on Image

### DIFF
--- a/Meta.Vlc.Wpf/VideoDisplayContext.cs
+++ b/Meta.Vlc.Wpf/VideoDisplayContext.cs
@@ -98,7 +98,10 @@ namespace Meta.Vlc.Wpf
             {
                 Image.Dispatcher.BeginInvoke(new Action(() =>
                 {
-                    Image.Invalidate();
+                    if (Image != null)
+                    {
+                        Image.Invalidate();
+                    }
                 }));
             }
         }


### PR DESCRIPTION
Every once in a while, Image will have a value so it schedules code on
the dispatcher, but then Image is set to null and finally the dispatched
method gets called. So I added an additional check for null inside the
dispatched action. I also fixed the possibility of Image becoming null
after the null check, but before calling the dispatcher (rare, but
possible).