### PR TITLE
Fix for libvlc_audio_set_format where wrong type was being marshalled

### DIFF
--- a/Meta.Vlc/Interop/LibVlc.MediaPlayer.cs
+++ b/Meta.Vlc/Interop/LibVlc.MediaPlayer.cs
@@ -371,7 +371,7 @@ namespace Meta.Vlc.Interop.MediaPlayer
     /// <param name="channels">通道数</param>
     [LibVlcFunction("libvlc_audio_set_format", "2.0.0")]
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate void SetAudioFormat(IntPtr mediaPlayer, uint format, uint rate, uint channels);
+    public delegate void SetAudioFormat(IntPtr mediaPlayer, [MarshalAs(UnmanagedType.LPArray)] byte[] format, uint rate, uint channels);
 
     /// <summary>
     ///     设置 Audio 的格式回调

--- a/Meta.Vlc/VlcMediaPlayer.cs
+++ b/Meta.Vlc/VlcMediaPlayer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
 using Meta.Vlc.Interop;
 using Meta.Vlc.Interop.Core.Events;
 using Meta.Vlc.Interop.Media;
@@ -965,9 +966,7 @@ namespace Meta.Vlc
         /// <param name="channels">通道数</param>
         public void SetAudioFormat(String format, uint rate, uint channels)
         {
-            var fmt =
-                BitConverter.ToUInt32(new[] { (byte)format[0], (byte)format[1], (byte)format[2], (byte)format[3] }, 0);
-            _setAudioFormatFunction.Delegate(InstancePointer, fmt, rate, channels);
+            _setAudioFormatFunction.Delegate(InstancePointer, Encoding.UTF8.GetBytes(format), rate, channels);
         }
 
         public int GetTitleChapterCount(int title)


### PR DESCRIPTION
Type accepted as 'format' by ``libvlc_audio_set_format`` is a const char *. ``VlcMediaPlayer.SetAudioFormat`` was converting strings to uint32 which causes an AccessViolationException no matter what value you provide as the ``format`` parameter.

Fixed by marshalling a byte array as LPArray, and then using Encoding.UTF8.GetBytes for the ``format`` parameter, which fixes the issue.