### PR TITLE
Don't free vlc_event_manager instances

### DIFF
--- a/Meta.Vlc/VlcEventManager.cs
+++ b/Meta.Vlc/VlcEventManager.cs
@@ -56,7 +56,8 @@ namespace Meta.Vlc
         public void Dispose()
         {
             HandleManager.Remove(this);
-            LibVlcManager.Free(InstancePointer);
+            // We should not free libvlc_event_manager instances as their life cycles are
+            // managed by their parent libvlc_media_player or libvlc_media instances.
             InstancePointer = IntPtr.Zero;
         }
 


### PR DESCRIPTION
The vlc_event_manager_t instances are created and destroyed
by their parent vlc_media_player_t or vlc_media_t instances,
so we should not try to free them ourselves.