### PR TITLE
Fixes in VlcMedia

### DIFF
--- a/Meta.Vlc.Wpf/VlcPlayer.DependencyProperties.cs
+++ b/Meta.Vlc.Wpf/VlcPlayer.DependencyProperties.cs
@@ -89,7 +89,8 @@ namespace Meta.Vlc.Wpf
                 new PropertyMetadata(Stretch.Uniform, (o, args) =>
                 {
                     var @this = o as VlcPlayer;
-
+                    if (@this == null)
+                        return;
                     if (@this.Image != null)
                     {
                         @this.Image.Stretch = (Stretch) args.NewValue;
@@ -110,8 +111,10 @@ namespace Meta.Vlc.Wpf
                 new PropertyMetadata(StretchDirection.Both, (o, args) =>
                 {
                     var @this = o as VlcPlayer;
+                    if (@this == null)
+                        return;
 
-                    if (@this.DisplayThreadDispatcher != null)
+                    if (@this.Image != null)
                     {
                         @this.Image.StretchDirection = (StretchDirection) args.NewValue;
                     }


### PR DESCRIPTION
Added Error property which is filled if State == Error
Added Detach of event callbacks in Dispose to fix
"CallbackOnCollectedDelegate" error in some cases
Fixed StateChanged event - for some reasons value in the event args
coming from libvlc internals is strange and does not belong to
MediaState enumeration, so call _getStateFunction explicitly to get
actual state value and provide it to subscribers