### PR TITLE
 - recreate VideoSoure on VideoDisplayContext;

### DIFF
--- a/Meta.Vlc.Wpf/VlcPlayer.Events.cs
+++ b/Meta.Vlc.Wpf/VlcPlayer.Events.cs
@@ -358,6 +358,7 @@ namespace Meta.Vlc.Wpf
                             _context.Dispose();
                         }
                         _context = new VideoDisplayContext(videoFormatChangingArgs.Width, videoFormatChangingArgs.Height, videoFormatChangingArgs.ChromaType);
+						VideoSource = null;
                     }));
             }
             


### PR DESCRIPTION
Recreating VideoSource on VideoDisplayContext change is absolutely necessary. It is very likely that picture buffer size will change on VideoDisplayContext change and this will cause to error in render-loop.